### PR TITLE
Use GitHub CLI to avoid GitHub rate limit

### DIFF
--- a/.github/workflows/au.yml
+++ b/.github/workflows/au.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Check update for packages
         run: ./update_all.ps1 -ForcedPackages '${{ github.event.inputs.forced_packages }}'
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # To authenticate GitHub CLI
           AU_DRY_RUN: ${{ github.event_name == 'push' }}
           # Github token to commit pushed packages to repository
           github_user_repo: ${{ github.repository }}

--- a/actionlint/update.ps1
+++ b/actionlint/update.ps1
@@ -2,8 +2,7 @@ import-module au
 
 function global:au_GetLatest {
   ## Find a latest release and extract installer URL from GitHub Releases
-  $releases = 'https://api.github.com/repos/rhysd/actionlint/releases'
-  $releases_info = Invoke-RestMethod -Uri $releases
+  $releases_info = gh api 'repos/rhysd/actionlint/releases' | ConvertFrom-Json
   foreach ($release in $releases_info) {
     if (-not $release.prerelease) {
       $tag = $release.tag_name

--- a/font-firge/update.ps1
+++ b/font-firge/update.ps1
@@ -2,8 +2,7 @@
 
 function global:au_GetLatest {
   ## Find a latest release and extract zip URL from GitHub Releases
-  $releases = 'https://api.github.com/repos/yuru7/Firge/releases'
-  $releases_info = Invoke-RestMethod -Uri $releases
+  $releases_info = gh api 'repos/yuru7/Firge/releases' | ConvertFrom-Json
   foreach ($release in $releases_info) {
     $tag = $release.tag_name
     if ($release.prerelease) {

--- a/font-hackgen/update.ps1
+++ b/font-hackgen/update.ps1
@@ -2,8 +2,7 @@
 
 function global:au_GetLatest {
   ## Find a latest release and extract zip URL from GitHub Releases
-  $releases = 'https://api.github.com/repos/yuru7/HackGen/releases'
-  $releases_info = Invoke-RestMethod -Uri $releases
+  $releases_info = gh api 'repos/yuru7/HackGen/releases' | ConvertFrom-Json
   foreach ($release in $releases_info) {
     $tag = $release.tag_name
     $pre = if ($release.prerelease) { '-pre' } else { '' }

--- a/mape/update.ps1
+++ b/mape/update.ps1
@@ -3,8 +3,7 @@ Import-Module au
 function global:au_GetLatest {
   ## Find a latest version from a5m2 history page
   $regex = [regex]'(?i)^mape_([.\d]+)_.*\.zip$'
-  $releases = 'https://api.github.com/repos/ipponshimeji/MAPE/contents/Releases?ref=master'
-  $releases_info = Invoke-RestMethod -Uri $releases
+  $releases_info = gh api 'repos/ipponshimeji/MAPE/contents/Releases?ref=master' | ConvertFrom-Json
   $latestRelease = $releases_info | Where-Object { $_.name -match $regex } `
     | Sort-Object { [System.Version]($regex.Match($_.name).Groups[1].Value) } -Descending `
     | Select-Object -First 1

--- a/navi/update.ps1
+++ b/navi/update.ps1
@@ -2,8 +2,7 @@
 
 function global:au_GetLatest {
   ## Find a latest release and extract installer URL from GitHub Releases
-  $releases = 'https://api.github.com/repos/denisidoro/navi/releases'
-  $releases_info = Invoke-RestMethod -Uri $releases
+  $releases_info = gh api 'repos/denisidoro/navi/releases' | ConvertFrom-Json
   foreach ($release in $releases_info) {
     if (-not $release.prerelease) {
       $tag = $release.tag_name

--- a/pet/update.ps1
+++ b/pet/update.ps1
@@ -2,8 +2,7 @@
 
 function global:au_GetLatest {
   ## Find a latest release and extract installer URL from GitHub Releases
-  $releases = 'https://api.github.com/repos/knqyf263/pet/releases'
-  $releases_info = Invoke-RestMethod -Uri $releases
+  $releases_info = gh api 'repos/knqyf263/pet/releases' | ConvertFrom-Json
   foreach ($release in $releases_info) {
     if (-not $release.prerelease) {
       $version = $release.tag_name -replace "^v",""


### PR DESCRIPTION
GitHub CLI with `GITHUB_TOKEN` has more limits than unauthorized requests.

Fix #20 